### PR TITLE
Closes #53

### DIFF
--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -78,6 +78,7 @@ export default {
 
   // src/main.ts
   'Open view': 'Open view',
+  'Focus on reference list view': 'Focus on reference list view',
 
   // src/view.ts
   'Open literature note': 'Open literature note',

--- a/src/main.ts
+++ b/src/main.ts
@@ -106,6 +106,13 @@ export default class ReferenceList extends Plugin {
         this.initLeaf();
       },
     });
+    this.addCommand({
+      id: "focus-reference-list-view",
+      name: t("Focus on reference list view"),
+      callback: () => {
+        this.activateView();
+      }
+    });
 
     document.body.toggleClass(
       'pwc-tooltips',
@@ -351,4 +358,15 @@ export default class ReferenceList extends Plugin {
       view?.setNoContentMessage();
     }
   };
+  async activateView() {
+    if (this.app.workspace.getLeavesOfType(viewType).length === 0) {
+      await this.app.workspace.getRightLeaf(false).setViewState({
+        type: viewType,
+        active: true,
+      });
+    }
+    this.app.workspace.revealLeaf(
+      this.app.workspace.getLeavesOfType(viewType)[0]
+    );
+  }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -104,6 +104,7 @@ export default class ReferenceList extends Plugin {
           return this.view === null;
         }
         this.initLeaf();
+        this.activateView();
       },
     });
     this.addCommand({


### PR DESCRIPTION
Closes #53.

Changes:
- addition of an executable & key-assignable command `Focus on reference list view` to activate and focus the reference-list
- Command `Open view` will activate and focus the view after calling `this.initLeaf()`.

This allows the user to either create the view if it doesn't exist yet, then focus it; or merely focus it when it is already active.
`Focus on reference list view` will initialise the view if it does not exist, before activating it


PR only contains sourcecode-changes, metadata-related changes are not included for simplicity - and due to the fact that I am not aware of your versioning conventions, so I don't want to make things messy.