### PR TITLE
citekey enhancements (auto completion and more)

### DIFF
--- a/src/bib/bibManager.ts
+++ b/src/bib/bibManager.ts
@@ -35,6 +35,9 @@ const fuseSettings = {
   includeMatches: true,
   threshold: 0.35,
   minMatchCharLength: 2,
+  ignoreLocation: true,
+  ignoreFieldNorm: true,
+  useExtendedSearch: true,
   keys: [
     { name: 'id', weight: 0.7 },
     { name: 'title', weight: 0.3 },

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -61,7 +61,7 @@ const alphaNumeric = /[\p{L}\p{N}]/u;
 const punct = /[:.#$%&\-+?<>~_/]/;
 const nonKeyPunct = /\p{P}/u;
 const space = /[ \t\v]/;
-const preKey = /[ \t\v[\-\r\n;]/;
+const preKey = /[\s()[\]{}\-;]/;
 const locatorRe =
   /^((?:[[(]?[a-z\p{N}]+[\])]?[-—:][[(]?[a-z\p{N}]+[\])]?|[a-z\p{N}()[\]]*\p{N}+[a-z\p{N}()[\]]*|[mdclxvi]+)(?:[ \t]*,[ \t]*(?:[[(]?[a-z\p{N}]+[\])]?[-—:][[(]?[a-z\p{N}]+[\])]?|[a-z\p{N}()[\]]*\p{N}+[a-z\p{N}()[\]]*|[mdclxvi]+))*)/iu;
 


### PR DESCRIPTION
Hello,

I started using your plugin for Obsidian and found the citekey feature a little lacking, so I quickly made some enhacements:

* You can now use `@"..."` to search for multiple strings (seperated by the space character ` `) inside the reference key and title. The citekey suggestions only contain items that have a fuzzy match for all strings.
* You can now use the citekey command's (`@"..."`)  suggestions feature when it is surrounded by whitespace (of any kind) or the following characters: `-`, `(`, `)`, `[`, `]`, `{`, `}`
* I made modifications to the search settings to improve search results for citekey suggestions 

Still To-Do:
[ ] fix displaying citekey commands when they are surrounded by the characters mentioned above (whitespace (of any kind) or the following characters: `-`, `(`, `)`, `[`, `]`, `{`, `}`)

I was able to fix the last issue by changing the `preKey` variable in `parser.ts:64` like this:
```
const preKey = /[\s()[\]{}\-;]/;
```

I successfully tested it on my machine. However, since I had no time to dive into how citekeys are displayed, I do not know if this fix has unwanted consequences.

