### PR TITLE
adapted code to allow for relative paths to bib-file in a files front…

### DIFF
--- a/src/bib/bibManager.ts
+++ b/src/bib/bibManager.ts
@@ -29,7 +29,7 @@ import { setCiteKeyCache } from 'src/editorExtension';
 import equal from 'fast-deep-equal';
 import { t } from 'src/lang/helpers';
 import path from 'path';
-import { FSWatcher, watch } from 'fs';
+import { FSWatcher, watch, existsSync } from 'fs';
 
 const fuseSettings = {
   includeMatches: true,
@@ -86,6 +86,11 @@ function getScopedSettings(file: TFile): ScopedSettings {
 
   if (Object.values(output).every((v) => !v)) {
     return null;
+  }
+
+  // Checks whether the bibliography is a relative path and replaces the path with an absolute one
+  if (existsSync(path.join(getVaultRoot(), path.dirname(file.path), output.bibliography))){
+    output.bibliography = path.join(getVaultRoot(), path.dirname(file.path), output.bibliography);
   }
 
   return output;

--- a/src/bib/helpers.ts
+++ b/src/bib/helpers.ts
@@ -20,7 +20,7 @@ export function getBibPath(bibPath: string, getVaultRoot?: () => string) {
     if (getVaultRoot) {
       bibPath = path.join(getVaultRoot(), bibPath);
       if (!fs.existsSync(bibPath)) {
-        throw new Error(`bibToCSL: cannot access bibliography file '${orig}'.`);
+        throw new Error(`bibToCSL: cannot access bibliography file '${bibPath}'.`);
       }
     } else {
       throw new Error(`bibToCSL: cannot access bibliography file '${orig}'.`);


### PR DESCRIPTION
# Motivation

The motivation for the changes is to allow relative paths to bibliographies in the frontmatter of a file, e.g.:

```
---
bibliography: ../../aBibtex.bib
---
```

The current plugin works only for absolute paths and file names when the file is located at the root of the Vault. However, Pandoc allows for relative paths. Adding the feature makes it simpler to keep the obsidian-markdown file easily convertible into standalone markdown files. That supports the distribution of files.

# Implementation

The implementation is fairly simple: When the bibliography path is extracted from the file, it is checked whether joining the directory of the viewed Markdown file and the bibliography results in a valid file path. If it does, then the joined path is taken for further processing.  It should not interfere with the current implementation.

I ran the tests of this project. However, some failed because the path to Pandoc is hard-coded to `/opt/homebrew/bin/pandoc` which does not align with my system. It is advisable to run the tests on the right machine again.