### PR TITLE
Support file-relative bibliography frontmatter

### DIFF
--- a/src/bib/bibManager.ts
+++ b/src/bib/bibManager.ts
@@ -1,6 +1,6 @@
 import { EditorView } from '@codemirror/view';
 import CSL from 'citeproc';
-import ReferenceList from 'src/main';
+import type ReferenceList from 'src/main';
 import { PartialCSLEntry } from './types';
 import Fuse from 'fuse.js';
 import {
@@ -44,7 +44,7 @@ const fuseSettings = {
 interface ScopedSettings {
   style?: string;
   lang?: string;
-  bibliography?: string;
+  bibliography?: string[];
 }
 
 export interface FileCache {
@@ -64,7 +64,35 @@ export interface FileCache {
   };
 }
 
-function getScopedSettings(file: TFile): ScopedSettings {
+function getFrontmatterString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function getFrontmatterStringList(value: unknown): string[] {
+  const values = Array.isArray(value) ? value : [value];
+  return values
+    .map(getFrontmatterString)
+    .filter((v): v is string => !!v);
+}
+
+function resolveScopedPath(file: TFile, scopedPath: string) {
+  if (path.isAbsolute(scopedPath)) return scopedPath;
+
+  const relativeToNote = path.join(
+    getVaultRoot(),
+    path.dirname(file.path),
+    scopedPath
+  );
+
+  if (existsSync(relativeToNote)) return relativeToNote;
+
+  return scopedPath;
+}
+
+export function getScopedSettings(file: TFile): ScopedSettings | null {
   const metadata = app.metadataCache.getFileCache(file);
   const output: ScopedSettings = {};
 
@@ -74,23 +102,21 @@ function getScopedSettings(file: TFile): ScopedSettings {
 
   const { frontmatter } = metadata;
 
-  output.bibliography = frontmatter.bibliography?.trim() || undefined;
+  const bibliography = getFrontmatterStringList(frontmatter.bibliography).map(
+    (bibPath) => resolveScopedPath(file, bibPath)
+  );
+  output.bibliography = bibliography.length ? bibliography : undefined;
   output.style =
-    frontmatter.csl?.trim() ||
-    frontmatter['citation-style']?.trim() ||
+    getFrontmatterString(frontmatter.csl) ||
+    getFrontmatterString(frontmatter['citation-style']) ||
     undefined;
   output.lang =
-    frontmatter.lang?.trim() ||
-    frontmatter['citation-language']?.trim() ||
+    getFrontmatterString(frontmatter.lang) ||
+    getFrontmatterString(frontmatter['citation-language']) ||
     undefined;
 
   if (Object.values(output).every((v) => !v)) {
     return null;
-  }
-
-  // Checks whether the bibliography is a relative path and replaces the path with an absolute one
-  if (existsSync(path.join(getVaultRoot(), path.dirname(file.path), output.bibliography))){
-    output.bibliography = path.join(getVaultRoot(), path.dirname(file.path), output.bibliography);
   }
 
   return output;
@@ -156,8 +182,10 @@ export class BibManager {
       max: 10,
       noDisposeOnSet: true,
       dispose: (cache) => {
-        if (cache.settings?.bibliography) {
-          this.clearWatcher(cache.settings.bibliography);
+        if (cache.settings?.bibliography?.length) {
+          for (const bibPath of cache.settings.bibliography) {
+            this.clearBibliographyWatcher(bibPath);
+          }
         }
       },
     });
@@ -183,6 +211,16 @@ export class BibManager {
     if (this.watcherCache.has(path)) {
       this.watcherCache.get(path).close();
       this.watcherCache.delete(path);
+    }
+  }
+
+  clearBibliographyWatcher(path: string) {
+    this.clearWatcher(path);
+
+    try {
+      this.clearWatcher(getBibPath(path, getVaultRoot));
+    } catch {
+      // The file may already be gone; clearing the original key is enough then.
     }
   }
 
@@ -245,6 +283,7 @@ export class BibManager {
         style = settings.style;
       } catch (e) {
         console.error(e);
+        this.plugin.view?.setMessage((e as Error).message);
         return this;
       }
     }
@@ -255,17 +294,23 @@ export class BibManager {
         lang = settings.lang;
       } catch (e) {
         console.error(e);
+        this.plugin.view?.setMessage((e as Error).message);
         return this;
       }
     }
 
-    if (settings.bibliography) {
+    if (settings.bibliography?.length) {
       try {
-        const bib = await bibToCSL(
-          settings.bibliography,
-          this.plugin.settings.pathToPandoc,
-          getVaultRoot
-        );
+        const bib: PartialCSLEntry[] = [];
+        for (const bibPath of settings.bibliography) {
+          bib.push(
+            ...(await bibToCSL(
+              bibPath,
+              this.plugin.settings.pathToPandoc,
+              getVaultRoot
+            ))
+          );
+        }
         bibCache = new Map();
 
         for (const entry of bib) {
@@ -275,7 +320,7 @@ export class BibManager {
         fuse = new Fuse(bib, fuseSettings);
       } catch (e) {
         console.error(e);
-        return this;
+        throw e;
       }
     }
 
@@ -625,13 +670,12 @@ export class BibManager {
       })
     );
 
-    const areSettingsEqual =
-      settings?.bibliography === cachedDoc?.settings?.bibliography &&
-      settings?.style === cachedDoc?.settings?.style &&
-      settings?.lang === cachedDoc?.settings?.lang;
+    const areSettingsEqual = equal(settings, cachedDoc?.settings);
 
-    if (!areSettingsEqual && cachedDoc?.settings?.bibliography) {
-      this.clearWatcher(cachedDoc.settings.bibliography);
+    if (!areSettingsEqual && cachedDoc?.settings?.bibliography?.length) {
+      for (const bibPath of cachedDoc.settings.bibliography) {
+        this.clearBibliographyWatcher(bibPath);
+      }
     }
 
     const source =
@@ -639,24 +683,33 @@ export class BibManager {
         ? cachedDoc.source
         : await this.loadScopedEngine(settings);
 
-    if (settings?.bibliography) {
-      const bibPath = getBibPath(settings.bibliography, getVaultRoot);
-      if (!this.watcherCache.has(bibPath)) {
-        let dbTimer = 0;
-        this.watcherCache.set(
-          bibPath,
-          watch(bibPath, (evt) => {
-            if (evt === 'change') {
-              clearTimeout(dbTimer);
-              dbTimer = activeWindow.setTimeout(() => {
-                this.fileCache.delete(file);
-                this.plugin.processReferences();
-              }, 100);
-            } else {
-              this.clearWatcher(bibPath);
-            }
-          })
-        );
+    if (settings?.bibliography?.length) {
+      for (const scopedBibPath of settings.bibliography) {
+        let bibPath: string;
+        try {
+          bibPath = getBibPath(scopedBibPath, getVaultRoot);
+        } catch (e) {
+          console.error(e);
+          continue;
+        }
+
+        if (!this.watcherCache.has(bibPath)) {
+          let dbTimer = 0;
+          this.watcherCache.set(
+            bibPath,
+            watch(bibPath, (evt) => {
+              if (evt === 'change') {
+                clearTimeout(dbTimer);
+                dbTimer = activeWindow.setTimeout(() => {
+                  this.fileCache.delete(file);
+                  this.plugin.processReferences();
+                }, 100);
+              } else {
+                this.clearWatcher(bibPath);
+              }
+            })
+          );
+        }
       }
     }
 
@@ -739,7 +792,10 @@ export class BibManager {
       : null;
 
     if (parsed) {
-      if (this.plugin.settings.pullFromZotero && !settings?.bibliography) {
+      if (
+        this.plugin.settings.pullFromZotero &&
+        !settings?.bibliography?.length
+      ) {
         await this.getZLinksForKeys(resolvedKeys);
       }
       parsed = this.prepBibHTML(parsed, file);

--- a/src/bib/helpers.ts
+++ b/src/bib/helpers.ts
@@ -61,7 +61,20 @@ export async function bibToCSL(
 
   const args = [bibPath, '-t', 'csljson', '--quiet'];
 
-  const res = await execa(pathToPandoc, args);
+  let res;
+  try {
+    res = await execa(pathToPandoc, args);
+  } catch (e) {
+    const stderr = (e as any)?.stderr || (e as any)?.shortMessage || '';
+    if (/Unknown output format csljson/.test(stderr)) {
+      throw new Error(
+        `Pandoc at '${pathToPandoc}' does not support CSL JSON output. ` +
+          'Please install Pandoc 2.11 or newer, then update the Pandoc path in this plugin settings if needed.'
+      );
+    }
+
+    throw e;
+  }
 
   if (res.stderr) {
     throw new Error(`bibToCSL: ${res.stderr}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,8 +3,11 @@ import {
   MarkdownView,
   Menu,
   Plugin,
+  TAbstractFile,
+  TFile,
   WorkspaceLeaf,
   debounce,
+  normalizePath,
   setIcon,
 } from 'obsidian';
 import which from 'which';
@@ -26,9 +29,77 @@ import { TooltipManager } from './tooltip';
 import { ReferenceListView, viewType } from './view';
 import { PromiseCapability, fixPath, getVaultRoot } from './helpers';
 import path from 'path';
-import { BibManager } from './bib/bibManager';
+import { BibManager, getScopedSettings } from './bib/bibManager';
 import { CiteSuggest } from './citeSuggest/citeSuggest';
 import { isZoteroRunning } from './bib/helpers';
+
+const bibliographyExtensions = new Set(['bib', 'json', 'yaml', 'yml']);
+
+function isBibliographyFile(file: TAbstractFile): file is TFile {
+  return file instanceof TFile && bibliographyExtensions.has(file.extension);
+}
+
+function getFileRelativePath(sourceFile: TFile, targetPath: string) {
+  const sourceDir = path.posix.dirname(sourceFile.path);
+  const relativePath = path.posix.relative(sourceDir, targetPath);
+
+  return relativePath || path.posix.basename(targetPath);
+}
+
+function bibliographyMatchesPath(
+  sourceFile: TFile,
+  bibliography: string,
+  targetPath: string
+) {
+  const sourceDir = path.posix.dirname(sourceFile.path);
+  const normalizedBibliography = normalizePath(bibliography);
+  const noteRelativePath = normalizePath(
+    path.posix.join(sourceDir, normalizedBibliography)
+  );
+  const vaultRelativePath = normalizePath(normalizedBibliography);
+
+  if (noteRelativePath === targetPath || vaultRelativePath === targetPath) {
+    return true;
+  }
+
+  if (path.isAbsolute(bibliography)) {
+    const targetFilePath = path.join(getVaultRoot(), targetPath);
+    return path.normalize(bibliography) === path.normalize(targetFilePath);
+  }
+
+  return false;
+}
+
+function updateBibliographyPath(
+  sourceFile: TFile,
+  bibliography: unknown,
+  oldPath: string,
+  newPath: string
+) {
+  const getUpdatedPath = (value: unknown) => {
+    if (
+      typeof value === 'string' &&
+      bibliographyMatchesPath(sourceFile, value, oldPath)
+    ) {
+      return getFileRelativePath(sourceFile, newPath);
+    }
+
+    return value;
+  };
+
+  if (Array.isArray(bibliography)) {
+    let changed = false;
+    const updated = bibliography.map((value) => {
+      const next = getUpdatedPath(value);
+      changed ||= next !== value;
+      return next;
+    });
+
+    return changed ? updated : bibliography;
+  }
+
+  return getUpdatedPath(bibliography);
+}
 
 export default class ReferenceList extends Plugin {
   settings: ReferenceListSettings;
@@ -152,6 +223,30 @@ export default class ReferenceList extends Plugin {
       )
     );
 
+    this.registerEvent(
+      app.vault.on(
+        'rename',
+        debounce(
+          async (file, oldPath) => {
+            await this.initPromise.promise;
+            await this.bibManager.initPromise.promise;
+
+            if (isBibliographyFile(file)) {
+              await this.updateBibliographyFrontmatter(oldPath, file.path);
+            }
+
+            const activeView = app.workspace.getActiveViewOfType(MarkdownView);
+            if (activeView?.file instanceof TFile) {
+              this.bibManager.fileCache.delete(activeView.file);
+              this.processReferences();
+            }
+          },
+          100,
+          true
+        )
+      )
+    );
+
     (async () => {
       this.initStatusBar();
       this.setStatusBarLoading();
@@ -170,6 +265,39 @@ export default class ReferenceList extends Plugin {
       .getLeavesOfType(viewType)
       .forEach((leaf) => leaf.detach());
     this.bibManager.destroy();
+  }
+
+  async updateBibliographyFrontmatter(oldPath: string, newPath: string) {
+    oldPath = normalizePath(oldPath);
+    newPath = normalizePath(newPath);
+
+    for (const file of this.app.vault.getMarkdownFiles()) {
+      const metadata = this.app.metadataCache.getFileCache(file);
+      if (!metadata?.frontmatter?.bibliography) continue;
+
+      let changed = false;
+      try {
+        await this.app.fileManager.processFrontMatter(file, (frontmatter) => {
+          const nextBibliography = updateBibliographyPath(
+            file,
+            frontmatter.bibliography,
+            oldPath,
+            newPath
+          );
+
+          if (nextBibliography !== frontmatter.bibliography) {
+            frontmatter.bibliography = nextBibliography;
+            changed = true;
+          }
+        });
+
+        if (changed) {
+          this.bibManager.fileCache.delete(file);
+        }
+      } catch (e) {
+        console.error(e);
+      }
+    }
   }
 
   statusBarIcon: HTMLElement;
@@ -324,7 +452,16 @@ export default class ReferenceList extends Plugin {
 
   processReferences = async () => {
     const { settings, view } = this;
-    if (!settings.pathToBibliography && !settings.pullFromZotero) {
+    const activeView = this.app.workspace.getActiveViewOfType(MarkdownView);
+    const scopedSettings = activeView
+      ? getScopedSettings(activeView.file)
+      : null;
+
+    if (
+      !settings.pathToBibliography &&
+      !settings.pullFromZotero &&
+      !scopedSettings?.bibliography?.length
+    ) {
       return view?.setMessage(
         t(
           'Please provide the path to your pandoc compatible bibliography file in the Pandoc Reference List plugin settings.'
@@ -332,7 +469,6 @@ export default class ReferenceList extends Plugin {
       );
     }
 
-    const activeView = this.app.workspace.getActiveViewOfType(MarkdownView);
     if (activeView) {
       try {
         const fileContent = await this.app.vault.cachedRead(activeView.file);
@@ -355,6 +491,7 @@ export default class ReferenceList extends Plugin {
         }
       } catch (e) {
         console.error(e);
+        view?.setMessage((e as Error).message);
       }
     } else {
       view?.setNoContentMessage();


### PR DESCRIPTION
Resolve frontmatter bibliography paths relative to the current note before falling back to the vault root, including list-valued bibliography entries.

Update bibliography frontmatter when referenced bibliography files are renamed, and surface clearer Pandoc csljson errors in the reference pane.